### PR TITLE
Set minimum Emacs version

### DIFF
--- a/cask-mode.el
+++ b/cask-mode.el
@@ -4,6 +4,7 @@
 
 ;; Author: Wilfred Hughes <me@wilfred.me.uk>
 ;; Version: 0.1
+;; Package-Requires: ((emacs "24.3"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
- Enabling lexical-binding
- Using setq-local

And Cask works on Emacs 24.3 or higher versions.
