### PR TITLE
Only match file named Cask

### DIFF
--- a/cask-mode.el
+++ b/cask-mode.el
@@ -83,7 +83,7 @@ for more details on the DSL accepted by Cask."
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist
-             '("Cask" . cask-mode))
+             '("\\`Cask\\'" . cask-mode))
 
 (provide 'cask-mode)
 ;;; cask-mode.el ends here


### PR DESCRIPTION
Without this any file that includes the string cask is put into
cask-mode, like cask-mode.el.
